### PR TITLE
scrollable tag cloud

### DIFF
--- a/frontend/index.template.html
+++ b/frontend/index.template.html
@@ -318,6 +318,11 @@
             flex-wrap: wrap;
             gap: 0.5rem;
             margin-bottom: 1rem;
+            max-height: 200px;
+            overflow-y: auto;
+            padding: 0.5rem;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
         }
 
         .filter-actions {


### PR DESCRIPTION
- Added max-height: 200px to limit the container height
- Added overflow-y: auto to enable vertical scrolling when content exceeds the max height
- Added padding: 0.5rem to prevent tags from touching the container edges
- Added a subtle border and border radius to visually distinguish the scrollable area