### PR TITLE
frontend not rely on arxivId

### DIFF
--- a/frontend/src/js/papers.js
+++ b/frontend/src/js/papers.js
@@ -215,7 +215,7 @@ const renderPaperRow = (paper) => {
             <td class="col-arxiv-id">
                 <a href="${paper.url}" class="arxiv-id" onclick="event.stopPropagation()" 
                    style="background-color: ${bgColor}">
-                    ${paper.arxivId}
+                    ${paper.arxivId || paper.id}
                 </a>
             </td>
             <td class="col-title" title="${paper.title}">${paper.title}</td>


### PR DESCRIPTION
out of scope todo:
* move arxiv categories to source-specific metadata in the extension (arxiv plugin)
* migrate arxivIds in papers/data to new format
* migrate arxiv categories in papers/data
  * aliases?
* script to backfill missing openreview data (e.g. title, authors, etc)
* get publication date for openreview
* use s2 api for paper reconciliation, getting arxiv IDs for openreview